### PR TITLE
Support for autoconf config.h

### DIFF
--- a/kdtree.c
+++ b/kdtree.c
@@ -25,6 +25,11 @@ IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 /* single nearest neighbor search written by Tamas Nepusz <tamas@cs.rhul.ac.uk> */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Autoconf minimises the number of compiler define (`-D`) flags needed by adding them to a file `config.h`  generated by the `autoheader` tool.  This tiny patch adds support for this mechanism (while not affecting non-autoconf builds). 